### PR TITLE
Add assignee_email to tickets stream

### DIFF
--- a/tap_zendesk/schemas/tickets.json
+++ b/tap_zendesk/schemas/tickets.json
@@ -149,7 +149,7 @@
               "integer"
             ]
           },
-          "value": { }
+          "value": {}
         },
         "type": [
           "null",
@@ -208,6 +208,12 @@
       "type": [
         "null",
         "integer"
+      ]
+    },
+    "assignee_email": {
+      "type": [
+        "null",
+        "string"
       ]
     },
     "subject": {
@@ -394,42 +400,78 @@
       ],
       "properties": {
         "id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "assignee_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "group_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "reason_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "requester_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "ticket_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "updated_at": {
-            "type": ["null", "string"],
-            "format": "date-time"
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
         },
         "created_at": {
-            "type": ["null", "string"],
-            "format": "date-time"
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
         },
         "url": {
-            "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "score": {
-            "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "reason": {
-            "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "comment": {
-            "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         }
       }
     },


### PR DESCRIPTION
Adds `assignee_email` to the tickets stream. Also does some minor formatting of the JSON.

Tickets object docs: https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/.
